### PR TITLE
Change node-sass version form 3.13.1 to 4.11.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9009,7 +9009,7 @@
       "requires": {
         "codemirror": "5.17.0",
         "jquery": "2.2.4",
-        "node-sass": "3.13.1",
+        "node-sass": "4.11.0",
         "prettier": "1.5.2",
         "require-dir": "0.3.2",
         "run-sequence": "1.2.2",


### PR DESCRIPTION
When I try install the aplication, I find this problem with a node-sass lib. This is because the 3.13.1 version don't exist nowadays.

```
> bson@0.2.22 install /tmp/YASGUI.server/node_modules/tingodb/node_modules/bson
> (node-gyp rebuild 2> builderror.log) || (exit 0)

make: Entering directory '/tmp/YASGUI.server/node_modules/tingodb/node_modules/bson/build'
  CXX(target) Release/obj.target/bson/ext/bson.o
bson.target.mk:99: recipe for target 'Release/obj.target/bson/ext/bson.o' failed
make: Leaving directory '/tmp/YASGUI.server/node_modules/tingodb/node_modules/bson/build'

> microtime@2.1.6 install /tmp/YASGUI.server/node_modules/microtime
> prebuild-install || node-gyp rebuild

prebuild-install info begin Prebuild-install version 2.2.0
prebuild-install info looking for local prebuild @ prebuilds/microtime-v2.1.6-node-v57-linux-x64.tar.gz
prebuild-install info looking for cached prebuild @ /home/amartinez/.npm/_prebuilds/https-github.com-wadey-node-microtime-releases-download-v2.1.6-microtime-v2.1.6-node-v57-linux-x64.tar.gz
prebuild-install info found cached prebuild 
prebuild-install info unpacking @ /home/amartinez/.npm/_prebuilds/https-github.com-wadey-node-microtime-releases-download-v2.1.6-microtime-v2.1.6-node-v57-linux-x64.tar.gz
prebuild-install info unpack resolved to /tmp/YASGUI.server/node_modules/microtime/build/Release/microtime.node
prebuild-install info unpack required /tmp/YASGUI.server/node_modules/microtime/build/Release/microtime.node successfully
prebuild-install info install Prebuild successfully installed!

> node-sass@3.13.1 install /tmp/YASGUI.server/node_modules/yasgui-yasqe/node_modules/node-sass
> node scripts/install.js

Downloading binary from https://github.com/sass/node-sass/releases/download/v3.13.1/linux-x64-57_binding.node
Cannot download "https://github.com/sass/node-sass/releases/download/v3.13.1/linux-x64-57_binding.node": 

HTTP error 404 Not Found

Hint: If github.com is not accessible in your location
      try setting a proxy via HTTP_PROXY, e.g. 

      export HTTP_PROXY=http://example.com:1234

or configure npm proxy via

      npm config set proxy http://example.com:8080

> gulp-express@0.3.5 install /tmp/YASGUI.server/node_modules/gulp-express
> echo "*** Please use [gulp-live-server] instead! *** "
```